### PR TITLE
Replace \\dontrun{} with \\donttest{} and fix C++ CI failures

### DIFF
--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -37,7 +37,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
-      run: cmake -S . -B build -G "${{ matrix.cmake_generator }}"
+      run: cmake -S . -B build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       run: cmake --build build --config Release

--- a/.github/workflows/cpp-tests.yml
+++ b/.github/workflows/cpp-tests.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             cmake_generator: "Unix Makefiles"
           - os: windows-latest
-            cmake_generator: "Visual Studio 17 2022"
+            cmake_generator: "Ninja"
 
     steps:
     - name: Checkout code
@@ -30,7 +30,11 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.16.x'
+        cmake-version: '3.28.x'
+
+    - name: Setup MSVC (Windows)
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Configure CMake
       run: cmake -S . -B build -G "${{ matrix.cmake_generator }}"
@@ -64,7 +68,7 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.16.x'
+        cmake-version: '3.28.x'
 
     - name: Configure CMake with SOBOL_NO_PRECOMPUTED_TABLES
       run: cmake -S . -B build -DCMAKE_CXX_FLAGS="-DSOBOL_NO_PRECOMPUTED_TABLES"
@@ -91,13 +95,15 @@ jobs:
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.16.x'
+        cmake-version: '3.28.x'
 
     - name: Configure CMake with coverage flags
       run: |
         cmake -S . -B build \
           -DCMAKE_CXX_FLAGS="--coverage -fprofile-arcs -ftest-coverage" \
-          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DENABLE_OPTIMIZATIONS=OFF
 
     - name: Build
       run: cmake --build build
@@ -107,9 +113,9 @@ jobs:
 
     - name: Generate coverage report
       run: |
-        lcov --capture --directory build --output-file coverage.info
-        lcov --remove coverage.info '/usr/*' --output-file coverage.info
-        lcov --list coverage.info
+        lcov --capture --directory build --output-file coverage.info --ignore-errors empty
+        lcov --remove coverage.info '/usr/*' --output-file coverage.info --ignore-errors empty
+        lcov --list coverage.info --ignore-errors empty
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/R/sobol_design.R
+++ b/R/sobol_design.R
@@ -30,7 +30,7 @@
 #' drop-in replacement.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Generate 100 parameter sets for two parameters
 #' design <- sobol_design(
 #'   lower = c(a = 0, b = 100),

--- a/R/sobol_generator.R
+++ b/R/sobol_generator.R
@@ -15,7 +15,7 @@
 #'   \item{initial_skip}{Initial skip value used at construction}
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Create a 3-dimensional Sobol generator
 #' gen <- sobol_generator(dimensions = 3)
 #'
@@ -79,7 +79,7 @@ sobol_generator <- function(dimensions, skip = 0) {
 #'   containing the next point in the Sobol sequence. Values are in [0, 1).
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' gen <- sobol_generator(dimensions = 3)
 #' point <- sobol_next(gen)
 #' print(point) # e.g., [0.5, 0.5, 0.5]
@@ -111,7 +111,7 @@ sobol_next <- function(x, ...) {
 #'   If n = 0, returns a 0 x dimensions matrix.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' gen <- sobol_generator(dimensions = 2)
 #' points <- sobol_next_n(gen, n = 10)
 #' print(dim(points)) # [1] 10  2
@@ -147,7 +147,7 @@ sobol_next_n <- function(x, n, ...) {
 #'   The primary purpose is the side effect of updating the internal state.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' gen <- sobol_generator(dimensions = 2)
 #' sobol_skip_to(gen, 100)
 #' point <- sobol_next(gen) # This is the 100th point (0-indexed)
@@ -182,7 +182,7 @@ sobol_skip_to <- function(x, index, ...) {
 #' @return A numeric value representing the current index (0-based).
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' gen <- sobol_generator(dimensions = 2)
 #' sobol_next(gen)
 #' sobol_next(gen)
@@ -212,7 +212,7 @@ sobol_index <- function(x, ...) {
 #' @return An integer representing the number of dimensions.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' gen <- sobol_generator(dimensions = 5)
 #' dims <- sobol_dimensions(gen)
 #' print(dims) # 5

--- a/R/sobol_points.R
+++ b/R/sobol_points.R
@@ -31,7 +31,7 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Generate 1000 points in 5 dimensions
 #' points <- sobol_points(n = 1000, dim = 5)
 #' dim(points) # [1] 1000    5

--- a/man/sobol_design.Rd
+++ b/man/sobol_design.Rd
@@ -41,7 +41,7 @@ function from the pomp-explore package, allowing for easy comparison and
 drop-in replacement.
 }
 \examples{
-\dontrun{
+\donttest{
 # Generate 100 parameter sets for two parameters
 design <- sobol_design(
   lower = c(a = 0, b = 100),

--- a/man/sobol_dimensions.Rd
+++ b/man/sobol_dimensions.Rd
@@ -18,7 +18,7 @@ An integer representing the number of dimensions.
 Returns the number of dimensions configured for the generator.
 }
 \examples{
-\dontrun{
+\donttest{
 gen <- sobol_generator(dimensions = 5)
 dims <- sobol_dimensions(gen)
 print(dims) # 5

--- a/man/sobol_generator.Rd
+++ b/man/sobol_generator.Rd
@@ -25,7 +25,7 @@ incremental point generation. The generator maintains internal state
 and allows for efficient generation of quasi-random sequences.
 }
 \examples{
-\dontrun{
+\donttest{
 # Create a 3-dimensional Sobol generator
 gen <- sobol_generator(dimensions = 3)
 

--- a/man/sobol_index.Rd
+++ b/man/sobol_index.Rd
@@ -19,7 +19,7 @@ Returns the current index of the generator, which is the index of the
 next point that will be generated.
 }
 \examples{
-\dontrun{
+\donttest{
 gen <- sobol_generator(dimensions = 2)
 sobol_next(gen)
 sobol_next(gen)

--- a/man/sobol_next.Rd
+++ b/man/sobol_next.Rd
@@ -20,7 +20,7 @@ Generates a single point from the Sobol sequence and advances the
 internal state of the generator.
 }
 \examples{
-\dontrun{
+\donttest{
 gen <- sobol_generator(dimensions = 3)
 point <- sobol_next(gen)
 print(point) # e.g., [0.5, 0.5, 0.5]

--- a/man/sobol_next_n.Rd
+++ b/man/sobol_next_n.Rd
@@ -23,7 +23,7 @@ Generates n consecutive points from the Sobol sequence and advances the
 internal state of the generator.
 }
 \examples{
-\dontrun{
+\donttest{
 gen <- sobol_generator(dimensions = 2)
 points <- sobol_next_n(gen, n = 10)
 print(dim(points)) # [1] 10  2

--- a/man/sobol_points.Rd
+++ b/man/sobol_points.Rd
@@ -38,7 +38,7 @@ which is useful for:
 }
 }
 \examples{
-\dontrun{
+\donttest{
 # Generate 1000 points in 5 dimensions
 points <- sobol_points(n = 1000, dim = 5)
 dim(points) # [1] 1000    5

--- a/man/sobol_skip_to.Rd
+++ b/man/sobol_skip_to.Rd
@@ -24,7 +24,7 @@ Sobol sequence. This allows for reproducible subsequences and parallel
 generation strategies.
 }
 \examples{
-\dontrun{
+\donttest{
 gen <- sobol_generator(dimensions = 2)
 sobol_skip_to(gen, 100)
 point <- sobol_next(gen) # This is the 100th point (0-indexed)


### PR DESCRIPTION
## Summary
Two changes addressing CRAN resubmission and preexisting CI failures:

### 1. Replace `\dontrun{}` with `\donttest{}` (CRAN review fix)
All examples can be executed by users (no missing software or API keys), so `\dontrun{}` is unnecessary. Replaced with `\donttest{}` in both roxygen comments (`R/`) and generated Rd files (`man/`) per CRAN reviewer Benjamin Altmann's feedback.

### 2. Fix C++ CI workflow (preexisting failures on `main`)
- **Windows C++ tests**: cmake 3.16.x doesn't support the `Visual Studio 17 2022` generator. Switched to `Ninja` generator + `ilammy/msvc-dev-cmd@v1` for MSVC environment setup.
- **All jobs**: Upgraded cmake from `3.16.x` → `3.28.x`.
- **Code coverage**: Added `--coverage` to linker flags, disabled optimizations during coverage builds, and added `--ignore-errors empty` to lcov commands to handle missing `.gcda` files gracefully.

## Review & Testing Checklist for Human
- [ ] Verify no `\dontrun{}` remains: `grep -r \"dontrun\" R/ man/`
- [ ] Confirm CI is green (all C++ test jobs including Windows)
- [ ] Run `R CMD check --as-cran` locally before CRAN resubmission

### Notes
The `\dontrun{}` → `\donttest{}` change is a mechanical text substitution with no logic changes. The CI fixes address failures that existed on `main` before this PR.

Link to Devin session: https://app.devin.ai/sessions/3413d366498a4e738395d701b4866e1f
Requested by: @alrobles
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alrobles/sobol/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->