### PR TITLE
Fix R Package Tests on Windows: use bash shell for R CMD INSTALL

### DIFF
--- a/.github/workflows/r-tests.yml
+++ b/.github/workflows/r-tests.yml
@@ -53,6 +53,7 @@ jobs:
       run: |
         R CMD INSTALL .
         Rscript -e 'library(sobol); testthat::test_dir("tests/testthat")'
+      shell: bash
       continue-on-error: false
 
     - name: Test coverage
@@ -114,6 +115,7 @@ jobs:
 
     - name: Install package
       run: R CMD INSTALL .
+      shell: bash
 
     - name: Run examples
       run: |


### PR DESCRIPTION
## Summary
Fixes the preexisting R Package Tests failures on Windows (R 4.2, 4.3, 4.4).

**Root cause:** On Windows, GitHub Actions defaults to PowerShell where `R` is an alias for `Invoke-History` (the history recall cmdlet). This causes `R CMD INSTALL .` to fail with:\n```\nA positional parameter cannot be found that accepts argument 'INSTALL'.\n```

**Fix:** Added `shell: bash` to the two steps that call `R CMD INSTALL .`:\n- \"Run R tests\" step (line 52, runs on all OS including Windows)\n- \"Install package\" step (line 116, currently ubuntu-only but now future-proofed)

This was failing on every `main` commit — not caused by PR #40.

## Review & Testing Checklist for Human
- [ ] Confirm R Package Tests pass on Windows (R 4.2, 4.3, 4.4) in CI

### Notes
Also normalized CRLF → LF line endings in `r-tests.yml` (same as was done for `cpp-tests.yml` in PR #40).

Link to Devin session: https://app.devin.ai/sessions/3413d366498a4e738395d701b4866e1f
Requested by: @alrobles
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alrobles/sobol/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->